### PR TITLE
Deleted script_server tests from launch file

### DIFF
--- a/cob_script_server/launch/script_server.launch
+++ b/cob_script_server/launch/script_server.launch
@@ -4,7 +4,4 @@
 	<!-- start script_server -->
 	<node pkg="cob_script_server" type="script_server.py" name="script_server" cwd="node" respawn="false" output="screen" />
 
-	<!-- include rostest -->
-	<include file="$(find cob_script_server)/launch/script_server.test" />
-
 </launch>

--- a/cob_script_server/launch/script_server.test
+++ b/cob_script_server/launch/script_server.test
@@ -1,6 +1,9 @@
 <?xml version="1.0"?>
 <launch>
 
+	<!-- include script_server -->
+	<include file="$(find cob_script_server)/launch/script_server.launch" />
+
 	<!-- test python interface -->
 	<!-- test trigger -->
 	<test test-name="trigger" pkg="cob_script_server" type="trigger.py" name="trigger_test_node" time-limit="30" />


### PR DESCRIPTION
The script_server tests were originally included in the normal script_server launch file and were executed in any rostest which uses the script_server. You can now run the tests by executing the script_server.test file separately.
