### PR TITLE
generic topic status monitor based on diagnostic updater

### DIFF
--- a/cob_monitoring/CMakeLists.txt
+++ b/cob_monitoring/CMakeLists.txt
@@ -5,6 +5,8 @@ find_package(catkin REQUIRED COMPONENTS roscpp diagnostic_updater topic_tools)
 
 catkin_package()
 
+include_directories(include ${catkin_INCLUDE_DIRS})
+
 add_executable(topic_status_monitor src/topic_status_monitor.cpp)
 target_link_libraries(topic_status_monitor ${catkin_LIBRARIES})
 

--- a/cob_monitoring/CMakeLists.txt
+++ b/cob_monitoring/CMakeLists.txt
@@ -1,9 +1,12 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(cob_monitoring)
 
-find_package(catkin REQUIRED COMPONENTS)
+find_package(catkin REQUIRED COMPONENTS roscpp diagnostic_updater topic_tools)
 
 catkin_package()
+
+add_executable(topic_status_monitor src/topic_status_monitor.cpp)
+target_link_libraries(topic_status_monitor ${catkin_LIBRARIES})
 
 ### Install ###
 install(PROGRAMS
@@ -16,4 +19,10 @@ install(PROGRAMS
           src/ntp_monitor.py
           src/wifi_monitor.py
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+install(TARGETS topic_status_monitor
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )

--- a/cob_monitoring/package.xml
+++ b/cob_monitoring/package.xml
@@ -14,6 +14,10 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <depend>diagnostic_updater</depend>
+  <depend>roscpp</depend>
+  <depend>topic_tools</depend>
+
   <exec_depend>actionlib</exec_depend>
   <exec_depend>cob_light</exec_depend>
   <exec_depend>cob_msgs</exec_depend>

--- a/cob_monitoring/src/topic_status_monitor.cpp
+++ b/cob_monitoring/src/topic_status_monitor.cpp
@@ -15,13 +15,23 @@ public:
     ros::NodeHandle nh;
   
     std::string hardware_id;
-    ros::param::get("~hardware_id", hardware_id);
     std::string topic_name;
-    ros::param::get("~topic_name", topic_name);
-    double min_freq;
-    ros::param::get("~min_freq", min_freq_);
+    //ros::param::get("~hardware_id", hardware_id);
+    //ros::param::get("~topic_name", topic_name);
+    //ros::param::get("~min_freq", min_freq_);
+    //ros::param::get("~max_freq", max_freq_);
 
-    ros::param::get("~max_freq", max_freq_);
+    std::vector<std::string> topics;
+    ros::param::get("~topics", topics);
+    topic_name = topics.front();
+    double hz, hzerror;
+    ros::param::get("~hz", hz);
+    ros::param::get("~hzerror", hzerror);
+    min_freq_ = hz-hzerror;
+    max_freq_ = hz+hzerror;
+    std::string diagnostic_name;
+    ros::param::get("~diagnostic_name", diagnostic_name);
+    hardware_id = diagnostic_name;
 
     diagnostic_updater_.setHardwareID(hardware_id);
 

--- a/cob_monitoring/src/topic_status_monitor.cpp
+++ b/cob_monitoring/src/topic_status_monitor.cpp
@@ -1,0 +1,81 @@
+#include <ros/ros.h>
+#include <topic_tools/shape_shifter.h>
+#include <diagnostic_updater/diagnostic_updater.h>
+#include <diagnostic_updater/update_functions.h>
+#include <diagnostic_updater/publisher.h>
+#include <boost/thread/mutex.hpp>
+
+
+
+class TopicStatusMonitor
+{
+public:
+  TopicStatusMonitor()
+  {
+    ros::NodeHandle nh;
+  
+    std::string hardware_id;
+    ros::param::get("~hardware_id", hardware_id);
+    std::string topic_name;
+    ros::param::get("~topic_name", topic_name);
+    double min_freq;
+    ros::param::get("~min_freq", min_freq_);
+
+    ros::param::get("~max_freq", max_freq_);
+
+    diagnostic_updater_.setHardwareID(hardware_id);
+
+    diagnostic_updater::FrequencyStatusParam freq_param(&min_freq_, &max_freq_, 0.1, 5); //min_freq, max_freq, tolerance (default: 0.1), window_size (default: 5)
+    diagnostic_updater::TimeStampStatusParam stamp_param(-1, 1); //min_acceptable (default: -1), max_acceptable (default: 5)
+    topic_diagnostic_task_.reset(new diagnostic_updater::TopicDiagnostic(topic_name, diagnostic_updater_, freq_param, stamp_param));
+
+    last_message_received_ = ros::Time(0);
+    timeout_ = ros::Duration(5.0);  //default stale timeout
+    generic_sub_ = nh.subscribe<topic_tools::ShapeShifter>(topic_name, 1, &TopicStatusMonitor::topicCallback, this);
+    diagnostic_timer_ = nh.createTimer(ros::Duration(1.0), &TopicStatusMonitor::updateDiagnostics, this);
+
+    diagnostic_timer_.start();
+  }
+
+  ~TopicStatusMonitor()
+  {}
+  
+
+  void updateDiagnostics(const ros::TimerEvent& event)
+  {
+    boost::mutex::scoped_lock lock(mutex_);
+    if(ros::Time::now() - last_message_received_ < timeout_)
+      diagnostic_updater_.update();
+  }
+
+  void topicCallback(const topic_tools::ShapeShifter::ConstPtr& msg)
+  {
+    boost::mutex::scoped_lock lock(mutex_);
+    last_message_received_ = ros::Time::now();
+    topic_diagnostic_task_->tick(last_message_received_);
+  }
+
+private:
+  diagnostic_updater::Updater diagnostic_updater_;
+  boost::shared_ptr< diagnostic_updater::TopicDiagnostic > topic_diagnostic_task_;
+
+  double min_freq_, max_freq_;
+
+  ros::Time last_message_received_;
+  ros::Duration timeout_;
+  boost::mutex mutex_;
+  ros::Subscriber generic_sub_;
+  ros::Timer diagnostic_timer_;
+};
+
+
+
+int main(int argc, char **argv)
+{
+  ros::init(argc, argv, "topic_status_monitor");
+  TopicStatusMonitor tsm;
+
+  ros::spin();
+
+  return 0;
+}


### PR DESCRIPTION
This is a node, I wrote once for another project that can be used to acquire diagnostics for any given topic.
It's superior to `hz_monitor` as it shows you a more detailed info on the topic status, it can also monitor TimeStamps in the header of the messages...and cpp is likely more efficient :wink:
