### PR TITLE
add proper print_functions import

### DIFF
--- a/cob_command_gui/src/knoeppkes.py
+++ b/cob_command_gui/src/knoeppkes.py
@@ -64,6 +64,7 @@ import gtk
 import os
 import sys
 import signal
+from __future__ import print_function
 
 import rospy
 import roslib

--- a/cob_monitoring/src/cpu_monitor.py
+++ b/cob_monitoring/src/cpu_monitor.py
@@ -35,7 +35,7 @@
 ##\author Kevin Watts
 # This file has been copied from https://github.com/PR2/pr2_computer_monitor in order to support this feature for indigo indepenendly from PR2 dependencies
 
-from __future__ import with_statement
+from __future__ import with_statement, print_function
 
 import traceback
 import threading

--- a/cob_monitoring/src/hd_monitor.py
+++ b/cob_monitoring/src/hd_monitor.py
@@ -35,7 +35,7 @@
 ##\author Kevin Watts
 # This file has been copied from https://github.com/PR2/pr2_computer_monitor in order to support this feature for indigo indepenendly from PR2 dependencies
 
-from __future__ import with_statement
+from __future__ import with_statement, print_function
 
 import traceback
 import threading

--- a/cob_monitoring/src/wifi_monitor.py
+++ b/cob_monitoring/src/wifi_monitor.py
@@ -36,7 +36,7 @@
 ##\brief Republishes the data from ddwrt/accesspoint onto diagnostics
 # This file has been copied from https://github.com/PR2/pr2_computer_monitor in order to support this feature for indigo indepenendly from PR2 dependencies
 
-from __future__ import with_statement
+from __future__ import with_statement, print_function
 
 import threading
 import sys


### PR DESCRIPTION
Well, I [**thought**](https://github.com/ipa320/cob_command_tools/pull/169#issuecomment-274154241) I added the imports...but apparently the commit was empty...so this is required for #169 