### PR TITLE
add auto_recover to new cob_helper_tools pkg

### DIFF
--- a/cob_command_tools/package.xml
+++ b/cob_command_tools/package.xml
@@ -16,6 +16,7 @@
 
   <exec_depend>cob_command_gui</exec_depend>
   <exec_depend>cob_dashboard</exec_depend>
+  <exec_depend>cob_helper_tools</exec_depend>
   <exec_depend>cob_interactive_teleop</exec_depend>
   <exec_depend>cob_monitoring</exec_depend>
   <exec_depend>cob_script_server</exec_depend>

--- a/cob_helper_tools/CMakeLists.txt
+++ b/cob_helper_tools/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(cob_helper_tools)
+
+find_package(catkin REQUIRED)
+
+catkin_package()
+
+#############
+## Install ##
+#############
+
+install(PROGRAMS
+  scripts/auto_recover.py
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)

--- a/cob_helper_tools/CMakeLists.txt
+++ b/cob_helper_tools/CMakeLists.txt
@@ -10,6 +10,6 @@ catkin_package()
 #############
 
 install(PROGRAMS
-  scripts/auto_recover.py
+  scripts/auto_init.py scripts/auto_recover.py
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )

--- a/cob_helper_tools/package.xml
+++ b/cob_helper_tools/package.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>cob_helper_tools</name>
+  <version>0.6.5</version>
+  <description>Helper scripts for Care-O-bot</description>
+
+  <maintainer email="fxm@ipa.fhg.de">Felix Messmer</maintainer>
+  <author email="fxm@ipa.fhg.de">Felix Messmer</author>
+
+  <license>LGPL</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <exec_depend>cob_msgs</exec_depend>
+  <exec_depend>cob_script_server</exec_depend>
+  <exec_depend>diagnostic_msgs</exec_depend>
+  <exec_depend>rospy</exec_depend>
+
+</package>

--- a/cob_helper_tools/scripts/auto_init.py
+++ b/cob_helper_tools/scripts/auto_init.py
@@ -1,0 +1,45 @@
+#!/usr/bin/python
+
+import rospy
+import tf
+
+from cob_msgs.msg import EmergencyStopState
+
+from simple_script_server import *
+sss = simple_script_server()
+
+class AutoInit():
+
+  def __init__(self):
+    self.components = rospy.get_param('~components', [])
+    self.em_state = 1  # assume EMSTOP
+    rospy.Subscriber("/emergency_stop_state", EmergencyStopState, self.em_cb)
+
+    # wait for all components to start
+    for component in self.components:
+      rospy.loginfo("waiting for %s to start", component)
+      rospy.wait_for_service("/" + component + "/driver/init")
+    
+    # wait for emergency_stop to be released
+    while not rospy.is_shutdown():
+      if self.em_state == 1: # EMSTOP
+        rospy.loginfo("auto_init: waiting for emergency stop to be released")
+        try:
+          rospy.sleep(1)
+        except rospy.exceptions.ROSInterruptException as e:
+          pass
+      else: # EMFREE or EMCONFIRMED
+        # call init for all components
+        rospy.loginfo("auto_init: initializing components")
+        for component in self.components:
+          sss.init(component)
+        break # done
+
+  def em_cb(self, msg):
+    self.em_state = msg.emergency_state
+
+if __name__ == "__main__":
+  rospy.init_node("auto_init")
+  rospy.loginfo("auto init running")
+  AI = AutoInit()
+  rospy.loginfo("auto init finished")

--- a/cob_helper_tools/scripts/auto_init.py
+++ b/cob_helper_tools/scripts/auto_init.py
@@ -17,22 +17,26 @@ class AutoInit():
 
     # wait for all components to start
     for component in self.components:
-      rospy.loginfo("waiting for %s to start", component)
+      rospy.loginfo("[auto_init]: Waiting for %s to start...", component)
       rospy.wait_for_service("/" + component + "/driver/init")
     
     # wait for emergency_stop to be released
     while not rospy.is_shutdown():
       if self.em_state == 1: # EMSTOP
-        rospy.loginfo("auto_init: waiting for emergency stop to be released")
+        rospy.loginfo("[auto_init]: Waiting for emergency stop to be released...")
         try:
           rospy.sleep(1)
         except rospy.exceptions.ROSInterruptException as e:
           pass
       else: # EMFREE or EMCONFIRMED
         # call init for all components
-        rospy.loginfo("auto_init: initializing components")
+        rospy.loginfo("[auto_init]: Initializing components")
         for component in self.components:
-          sss.init(component)
+          handle = sss.init(component)
+          if not (handle.get_error_code() == 0):
+            rospy.logerr("[auto_init]: Could not initialize %s", component)
+          else:
+            rospy.loginfo("[auto_init]: Component %s initialized successfully", component)
         break # done
 
   def em_cb(self, msg):

--- a/cob_helper_tools/scripts/auto_init.py
+++ b/cob_helper_tools/scripts/auto_init.py
@@ -1,4 +1,30 @@
 #!/usr/bin/python
+#################################################################
+##\file
+#
+# \note
+#   Copyright (c) Felix Messmer \n
+#   Fraunhofer Institute for Manufacturing Engineering
+#   and Automation (IPA) \n
+#
+#   All rights reserved. \n\n
+#
+#################################################################
+#
+# \note
+#   Repository name: cob_command_tools
+# \note
+#   ROS package name: cob_helper_tools
+#
+# \author
+#   Author: Felix Messmer
+#
+# \date Date of creation: January 2017
+#
+# \brief
+#   A script to automatically initialize hardware on startup
+#
+#################################################################
 
 import rospy
 import tf
@@ -19,7 +45,7 @@ class AutoInit():
     for component in self.components:
       rospy.loginfo("[auto_init]: Waiting for %s to start...", component)
       rospy.wait_for_service("/" + component + "/driver/init")
-    
+
     # wait for emergency_stop to be released
     while not rospy.is_shutdown():
       if self.em_state == 1: # EMSTOP

--- a/cob_helper_tools/scripts/auto_recover.py
+++ b/cob_helper_tools/scripts/auto_recover.py
@@ -1,4 +1,30 @@
 #!/usr/bin/python
+#################################################################
+##\file
+#
+# \note
+#   Copyright (c) Felix Messmer \n
+#   Fraunhofer Institute for Manufacturing Engineering
+#   and Automation (IPA) \n
+#
+#   All rights reserved. \n\n
+#
+#################################################################
+#
+# \note
+#   Repository name: cob_command_tools
+# \note
+#   ROS package name: cob_helper_tools
+#
+# \author
+#   Author: Felix Messmer
+#
+# \date Date of creation: January 2017
+#
+# \brief
+#   A script to automatically recover hardware after e-stop and HW failure
+#
+#################################################################
 
 import rospy
 

--- a/cob_helper_tools/scripts/auto_recover.py
+++ b/cob_helper_tools/scripts/auto_recover.py
@@ -1,0 +1,45 @@
+#!/usr/bin/python
+
+import rospy
+
+from cob_msgs.msg import EmergencyStopState
+from diagnostic_msgs.msg import DiagnosticArray
+
+from simple_script_server import *
+sss = simple_script_server()
+
+class AutoRecover():
+
+  def __init__(self):
+    self.components = rospy.get_param('~components', [])
+    self.em_state = 0
+    rospy.Subscriber("/emergency_stop_state", EmergencyStopState, self.em_cb)
+    rospy.Subscriber("/diagnostics_agg", DiagnosticArray, self.diagnostics_cb)
+    self.last_time_recover = rospy.Time.now()
+
+  def em_cb(self, msg):
+    if msg.emergency_state != self.em_state:
+      if msg.emergency_state == 0:
+        rospy.loginfo("auto_recover from scanner stop")
+        self.recover()
+      self.em_state = msg.emergency_state
+
+  def recover(self):
+    # call recover for all components
+    for component in self.components:
+      handle = sss.recover(component)
+    self.last_time_recover = rospy.Time.now()
+
+  # auto recover based on diagnostics
+  def diagnostics_cb(self, msg):
+    for status in msg.status:
+      if status.level > 1: # only recover on error, not on warning status
+        if "Actuators" in status.name and self.em_state == 0 and (rospy.Time.now() - self.last_time_recover) > rospy.Duration(10):
+          self.recover()
+
+if __name__ == "__main__":
+
+  rospy.init_node("auto_recover")
+  AR = AutoRecover()
+  rospy.loginfo("auto recover running")
+  rospy.spin()

--- a/cob_helper_tools/scripts/auto_recover.py
+++ b/cob_helper_tools/scripts/auto_recover.py
@@ -28,6 +28,10 @@ class AutoRecover():
     # call recover for all components
     for component in self.components:
       handle = sss.recover(component)
+      if not (handle.get_error_code() == 0):
+        rospy.logerr("[auto_recover]: Could not recover %s", component)
+      else:
+        rospy.loginfo("[auto_recover]: Component %s recovered successfully", component)
     self.last_time_recover = rospy.Time.now()
 
   # auto recover based on diagnostics
@@ -35,10 +39,10 @@ class AutoRecover():
     for status in msg.status:
       if status.level > 1: # only recover on error, not on warning status
         if "Actuators" in status.name and self.em_state == 0 and (rospy.Time.now() - self.last_time_recover) > rospy.Duration(10):
+          rospy.loginfo("auto_recover from diagnostic failure")
           self.recover()
 
 if __name__ == "__main__":
-
   rospy.init_node("auto_recover")
   AR = AutoRecover()
   rospy.loginfo("auto recover running")


### PR DESCRIPTION
@ipa-jba @ipa-mig @ipa-fmw 
How do you like this?
Related to https://github.com/ipa320/ipa_navigation_common/pull/90

I took msh-version and made it configurable via rosparam. You can use it like - **Usage updated**:
```
<?xml version="1.0" ?>
<launch>
  <node pkg="cob_helper_tools" type="auto_recover.py" name="auto_recover" output="screen">
    <rosparam param="components">[base, torso]</rosparam>
  </node>
</launch>
```

Please comment in case something from the navigation-version is not yet covered by this script!
Also, we might want to consider other scripts from msh to this new package for more prominent usage...e.g. auto_init, auto_localisation,...anything else?
The name is pretty general, so we might even put some fake nodes in here such as the ones from soon-to-be-removed `cob_controller_configuration_gazebo`