### PR TITLE
add fake_driver

### DIFF
--- a/cob_helper_tools/CMakeLists.txt
+++ b/cob_helper_tools/CMakeLists.txt
@@ -11,5 +11,6 @@ catkin_package()
 
 install(PROGRAMS
   scripts/auto_init.py scripts/auto_recover.py
+  scripts/fake_driver.py
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )

--- a/cob_helper_tools/scripts/fake_driver.py
+++ b/cob_helper_tools/scripts/fake_driver.py
@@ -1,0 +1,51 @@
+#!/usr/bin/python
+#################################################################
+##\file
+#
+# \note
+#   Copyright (c) Felix Messmer \n
+#   Fraunhofer Institute for Manufacturing Engineering
+#   and Automation (IPA) \n
+#
+#   All rights reserved. \n\n
+#
+#################################################################
+#
+# \note
+#   Repository name: cob_command_tools
+# \note
+#   ROS package name: cob_helper_tools
+#
+# \author
+#   Author: Felix Messmer
+#
+# \date Date of creation: January 2017
+#
+# \brief
+#   A script providing services to fake a (ros_canopen) driver
+#
+#################################################################
+
+import rospy
+from std_srvs.srv import *
+
+class FakeDriver():
+
+    def __init__(self):
+        self.init_srv = rospy.Service('driver/init', Trigger, self.srv_cb)
+        self.recover_srv = rospy.Service('driver/recover', Trigger, self.srv_cb)
+        self.halt_srv = rospy.Service('driver/halt', Trigger, self.srv_cb)
+        self.shutdown_srv = rospy.Service('driver/shutdown', Trigger, self.srv_cb)
+
+    def srv_cb(self, req):
+        resp = TriggerResponse()
+        resp.success = True
+        return resp
+
+
+if __name__ == "__main__":
+   rospy.init_node('fake_driver')
+   FakeDriver()
+   rospy.loginfo("fake_driver running")
+   rospy.spin()
+


### PR DESCRIPTION
previously been implemented as `cob_controller_configuration_gazebo/scripts/gazebo_services.py`
moving this from `cob_controller_configuration_gazebo` which is removed in https://github.com/ipa320/cob_robots/pull/611