### PR TITLE
update psutil api

### DIFF
--- a/cob_monitoring/src/cpu_monitor.py
+++ b/cob_monitoring/src/cpu_monitor.py
@@ -535,7 +535,10 @@ class CPUMonitor():
         self._load1_threshold = rospy.get_param('~load1_threshold', 5.0)
         self._load5_threshold = rospy.get_param('~load5_threshold', 3.0)
 
-        self._num_cores = rospy.get_param('~num_cores', psutil.NUM_CPUS)
+        if versiontuple(psutil.__version__) < versiontuple('2.0.0'):
+            self._num_cores = rospy.get_param('~num_cores', psutil.NUM_CPUS)
+        else:
+            self._num_cores = rospy.get_param('~num_cores', psutil.cpu_count())
 
         self._temps_timer = None
         self._usage_timer = None


### PR DESCRIPTION
makes #180 obsolete as `cpu_monitor.py` is now usable with both ROS distros (indigo, kinetic)

See [psutil API CHANGELOG](https://gemnasium.com/pypi/psutil/versions/2.0.0):
```
- psutil.* module level constants have being replaced by functions:

  +-----------------------+-------------------------------+
  | Old name              | Replacement                   |
  +=======================+===============================+
  | psutil.NUM_CPUS       | psutil.cpu_cpunt()            |
  +-----------------------+-------------------------------+
```
