### PR TITLE
dual distro compatibility for qt

### DIFF
--- a/cob_dashboard/src/cob_dashboard/cob_dashboard.py
+++ b/cob_dashboard/src/cob_dashboard/cob_dashboard.py
@@ -39,10 +39,12 @@ from rqt_robot_dashboard.dashboard import Dashboard
 from rqt_robot_dashboard.widgets import MonitorDashWidget, ConsoleDashWidget
 
 from python_qt_binding.QtCore import QSize
-from python_qt_binding.QtGui import QMessageBox
+try:
+    from python_qt_binding.QtWidgets import QMessageBox  # Qt 5
+except ImportError:
+	from python_qt_binding.QtGui import QMessageBox # Qt 4
 
 from cob_battery import COBBattery
-
 from cob_runstops import COBRunstops
 
 


### PR DESCRIPTION
migration hint: http://wiki.ros.org/kinetic/Migration#Qt4.2BAC8-Qt5_Guidelines

inspiration taken from https://github.com/ros-visualization/rqt_reconfigure/blob/master/src/rqt_reconfigure/treenode_status.py#L36-L39