### PR TITLE
[cob_console] hotfix for ipython shebang

### DIFF
--- a/cob_script_server/src/cob_console
+++ b/cob_script_server/src/cob_console
@@ -1,4 +1,4 @@
-#!/usr/bin/env python -i
+#!/usr/bin/ipython -i
 #
 # Copyright 2017 Fraunhofer Institute for Manufacturing Engineering and Automation (IPA)
 #


### PR DESCRIPTION
got lost duing licence header updates

was messed up during APACHE license change