### PR TITLE
Sound emergency stop monitor

### DIFF
--- a/cob_monitoring/src/battery_monitor.py
+++ b/cob_monitoring/src/battery_monitor.py
@@ -64,6 +64,9 @@ class battery_monitor():
                 return
             self.sound_components = rospy.get_param("~sound_components")
 
+        self.sound_critical = rospy.get_param("~sound_critical", "My battery is empty, please recharge now.")
+        self.sound_warning = rospy.get_param("~sound_warning", "My battery is nearly empty, please consider recharging.")
+
         self.last_time_warned = rospy.get_time()
         self.last_time_power_received = rospy.get_time()
         rospy.Subscriber(self.topic_name, PowerState, self.power_callback)
@@ -131,7 +134,7 @@ class battery_monitor():
                 mode.pulses = 4
                 self.set_light(mode)
 
-                self.say("My battery is empty, please recharge now.")
+                self.say(self.sound_critical)
 
             # 10%
             elif self.power_state.relative_remaining_capacity <= self.threshold_error and (rospy.get_time() - self.last_time_warned) > 15:
@@ -156,7 +159,7 @@ class battery_monitor():
                 mode.pulses = 2
                 self.set_light(mode)
 
-                self.say("My battery is nearly empty, please consider recharging.")
+                self.say(self.sound_warning)
 
         if self.is_charging == False and self.power_state.charging == True:
             self.is_charging = True

--- a/cob_monitoring/src/emergency_stop_monitor.py
+++ b/cob_monitoring/src/emergency_stop_monitor.py
@@ -56,6 +56,13 @@ class emergency_stop_monitor():
 				sys.exit(1)
 			self.sound_components = rospy.get_param("~sound_components")
 
+		self.sound_em_released = rospy.get_param("~sound_em_released", "emergency stop released")
+		self.sound_em_acknowledged = rospy.get_param("~sound_em_acknowledged", "emergency stop acknowledged")
+		self.sound_em_laser_issued = rospy.get_param("~sound_em_laser_issued", "laser emergency stop issued")
+		self.sound_em_button_issued = rospy.get_param("~sound_em_button_issued", "emergency stop button pressed")
+		self.sound_em_stop_issued = rospy.get_param("~sound_em_stop_issued", "emergency stop issued")
+		self.sound_em_unknown_issued = rospy.get_param("~sound_em_unknown_issued", "unknown emergency status issued")
+
 		#emergency_stop_monitoring always enabled
 		rospy.Subscriber("/emergency_stop_state", EmergencyStopState, self.emergency_callback, queue_size=1)
 		self.em_status = -1
@@ -86,24 +93,24 @@ class emergency_stop_monitor():
 
 			if msg.emergency_state == 0: # ready
 				self.stop_light()
-				self.say("emergency stop released")
+				self.say(self.sound_em_released)
 				self.diag_status = -1
 				self.motion_status = -1
 			elif msg.emergency_state == 1: # em stop
 				self.set_light(self.color_error)
 				if msg.scanner_stop and not msg.emergency_button_stop:
-					self.say("laser emergency stop issued")
+					self.say(self.sound_em_laser_issued)
 				elif not msg.scanner_stop and msg.emergency_button_stop:
-					self.say("emergency stop button pressed")
+					self.say(self.sound_em_button_issued)
 				else:
-					self.say("emergency stop issued")
+					self.say(self.sound_em_stop_issued)
 			elif msg.emergency_state == 2: # release
 				self.set_light(self.color_warn)
-				self.say("emergency stop acknowledged")
+				self.say(self.sound_em_acknowledged)
 			else:
 				rospy.logerr("Unknown emergency status issued: %s",str(msg.emergency_state))
 				self.set_light(self.color_error)
-				self.say("Unknown emergency status issued")
+				self.say(self.sound_em_unknown_issued)
 
 
 	## Diagnostics monitoring


### PR DESCRIPTION
allows to specify the say output for emergency and battery monitor in `emergency_stop_monitor.yaml` and `battery_monitor.yaml` (in `pkg_hardware_config`) respectively

default behavior is unchanged, so no PR for `cob_robots` needed