### PR TITLE
use private parameters for generic_throttle

### DIFF
--- a/generic_throttle/README.md
+++ b/generic_throttle/README.md
@@ -6,13 +6,12 @@ The package is composed of
 - `GenericThrottle`: class implementing the throttle
 - `generic_throttle_node`: ROS node wrapping around an instance of `GenericThrottle`
 
-The parameters are set with ROS parameters. An example of .yaml file:
+The parameters are set as privat parameters of the node. An example .yaml file could look like this:
 ```
-test_throttle:          # Throttle namespace
-  topics:               # List of topics to be throttled
-    - /topic1: {latched: False, lazy: True, topic_rate: 1.0}
-    - /topic2: {latched: True, lazy: False, topic_rate: 20.0}
-    - /image_topic: {latched: False, lazy: True, topic_rate: 20.0, resolution_factor: 0.5}
+topics:               # List of topics to be throttled
+  - /topic1: {latched: False, lazy: True, topic_rate: 1.0}
+  - /topic2: {latched: True, lazy: False, topic_rate: 20.0}
+  - /image_topic: {latched: False, lazy: True, topic_rate: 20.0, resolution_factor: 0.5}
 ```
 For each topic, 3 parameters must be specified:
 - `latched`: if `True`, the publisher of the throttled topic acts as latched (see  http://docs.ros.org/api/rospy/html/rospy.topics.Publisher-class.html)

--- a/generic_throttle/src/generic_throttle/generic_throttle.py
+++ b/generic_throttle/src/generic_throttle/generic_throttle.py
@@ -31,13 +31,10 @@ class GenericThrottle:
 
         mandatory_parameters = ['topic_rate','latched', 'lazy']
 
-        topics_param_name = str(rospy.get_namespace()) + '/topics'
-
-        if rospy.has_param(topics_param_name):
-            topics_list = rospy.get_param(topics_param_name)
-        else:
+        topics_param_name = '~topics'
+        if not rospy.has_param(topics_param_name):
             rospy.logerr('Parameter ' + topics_param_name + ' not available')
-            exit(5)
+        topics_list = rospy.get_param(topics_param_name, [])
 
         # create dictionary out of the topic list
         self.topics = {item.keys()[0]: item.values()[0] for item in topics_list}


### PR DESCRIPTION
is easier to configure, e.g. like so, i.e. without yaml file (see https://github.com/unity-robotics/unity_robots/pull/25):
```
<node ns="$(arg name)" pkg="generic_throttle" type="generic_throttle_node.py" name="generic_throttle">
	<rosparam subst_value="True">{topics: [/$(arg name)_upright/rgb/image_raw: {latched: False, lazy: True, topic_rate: 1.0, resolution_factor: 0.5}, /$(arg name)_upright/depth_registered/points: {latched: False, lazy: True, topic_rate: 1.0}] }</rosparam>
</node>
```