### PR TITLE
add missing dependency python-gtk2

### DIFF
--- a/cob_command_gui/package.xml
+++ b/cob_command_gui/package.xml
@@ -15,6 +15,7 @@
 
   <exec_depend>cob_msgs</exec_depend>
   <exec_depend>cob_script_server</exec_depend>
+  <exec_depend>python-gtk2</exec_depend>
   <exec_depend>python-pygraphviz</exec_depend>
   <exec_depend>roslib</exec_depend>
   <exec_depend>rospy</exec_depend>


### PR DESCRIPTION
`knoeppkes.py` needs `python-gtk2`: https://github.com/ipa320/cob_command_tools/blob/indigo_dev/cob_command_gui/src/knoeppkes.py#L19

wait for https://github.com/ros/rosdistro/pull/16812