### PR TITLE
use joint_names from component ns

### DIFF
--- a/cob_script_server/src/simple_script_server/simple_script_server.py
+++ b/cob_script_server/src/simple_script_server/simple_script_server.py
@@ -452,7 +452,7 @@ class simple_script_server:
 	## Parse and compose trajectory message
 	def compose_trajectory(self, component_name, parameter_name):
 		# get joint_names from parameter server
-		param_string = self.ns_global_prefix + "/" + component_name + "/joint_names"
+		param_string = "/" + component_name + "/joint_names"
 		if not rospy.has_param(param_string):
 			rospy.logerr("parameter %s does not exist on ROS Parameter Server, aborting...",param_string)
 			return (JointTrajectory(), 2)


### PR DESCRIPTION
this allows to remove the redundant `joint_names` parameter in `XX_default_robot_config`...instead we use the `joint_names` from the `XX_controller.yaml`...
the obsolete parameters are removed in https://github.com/unity-robotics/unity_robots/pull/55
(ipa320/cob_robots will follow as soon as I migrate the structure...it's still working for the time being without removing them ;-)