### PR TITLE
Revert "use joint_names from component ns"

### DIFF
--- a/cob_script_server/src/simple_script_server/simple_script_server.py
+++ b/cob_script_server/src/simple_script_server/simple_script_server.py
@@ -452,7 +452,7 @@ class simple_script_server:
 	## Parse and compose trajectory message
 	def compose_trajectory(self, component_name, parameter_name):
 		# get joint_names from parameter server
-		param_string = "/" + component_name + "/joint_names"
+		param_string = self.ns_global_prefix + "/" + component_name + "/joint_names"
 		if not rospy.has_param(param_string):
 			rospy.logerr("parameter %s does not exist on ROS Parameter Server, aborting...",param_string)
 			return (JointTrajectory(), 2)


### PR DESCRIPTION
Reverts ipa320/cob_command_tools#219

Initially with the good intention to reduce obsolete parameters, #219 introduced more trouble than benefit
Thus,I'll revert...then, it's back to how it has been released in `0.6.7`