### PR TITLE
add missing dependency python-requests

### DIFF
--- a/cob_monitoring/package.xml
+++ b/cob_monitoring/package.xml
@@ -29,6 +29,7 @@
   <exec_depend>paramiko</exec_depend>
   <exec_depend>python-mechanize</exec_depend>
   <exec_depend>python-psutil</exec_depend>
+  <exec_depend>python-requests</exec_depend>
   <exec_depend>rospy</exec_depend>
   <exec_depend>rostopic</exec_depend>
   <exec_depend>sensor_msgs</exec_depend>


### PR DESCRIPTION
needed by `cpu_monitor.py`