### PR TITLE
Increase field size of 'number' in ScriptState

### DIFF
--- a/cob_script_server/msg/ScriptState.msg
+++ b/cob_script_server/msg/ScriptState.msg
@@ -1,5 +1,5 @@
 Header header
-int16 number
+uint32 number
 string function_name
 string component_name
 string parameter_name


### PR DESCRIPTION
Noticed an overflow in this field due to too many calls without shutdown on the SimpleScriptServer
With uint32 and an action being called every second, the SimpleScriptServer can go on for 136 years which I think should be sufficient

 - fixes https://github.com/mojin-robotics/cob4/issues/1136
 - new source code files added (proper [APACHE license header](https://github.com/ipa320/setup/tree/master/templates) **must** be used)
