### PR TITLE
feature/faster sss trajectories

### DIFF
--- a/cob_script_server/src/simple_script_server/simple_script_server.py
+++ b/cob_script_server/src/simple_script_server/simple_script_server.py
@@ -499,6 +499,10 @@ class simple_script_server:
 
 	## Parse and compose trajectory message
 	def compose_trajectory(self, component_name, parameter_name, speed_factor=1.0, urdf_vel=False, default_vel=None):
+		if urdf_vel and default_vel:
+			rospy.logerr("arguments not valid - cannot set 'urdf_vel' and 'default_vel' at the same time, aborting...")
+			return (JointTrajectory(), 3)
+
 		# get joint_names from parameter server
 		param_string = self.ns_global_prefix + "/" + component_name + "/joint_names"
 		if not rospy.has_param(param_string):

--- a/cob_script_server/src/simple_script_server/simple_script_server.py
+++ b/cob_script_server/src/simple_script_server/simple_script_server.py
@@ -675,7 +675,7 @@ class simple_script_server:
 					#  o--------------->
 					#         t     d_max
 					s2 = d_max[i] - 2 * s1[i]
-					t2 = s2[i] / default_vel[i]
+					t2 = s2 / default_vel[i]
 					t[i] = 2 * t1[i] + t2
 				else:
 					# If we don't have enough distance to get to full speed, then we do

--- a/cob_script_server/src/simple_script_server/simple_script_server.py
+++ b/cob_script_server/src/simple_script_server/simple_script_server.py
@@ -578,7 +578,7 @@ class simple_script_server:
 		# get current pos
 		timeout = 3.0
 		try:
-			joint_state = rospy.wait_for_message("/" + component_name + "/joint_states", JointState, timeout = timeout)
+			joint_state = rospy.wait_for_message("/" + component_name + "/joint_states", JointState, timeout=timeout)  # type: JointState
 			# make sure we have the same joint order
 			start_pos = []
 			for name in joint_names:
@@ -602,6 +602,15 @@ class simple_script_server:
 		else:
 			default_vel = rospy.get_param(param_string)
 
+		robot_urdf = URDF.from_parameter_server()
+		velocities = []
+		for joint_name in joint_names:
+			try:
+				velocities.append(robot_urdf.joint_map[joint_name].limit.velocity)
+			except KeyError:
+				velocities.append(default_vel)
+		rospy.logdebug("Velocities are: {}".format(velocities))
+
 		param_string = self.ns_global_prefix + "/" + component_name + "/default_acc"
 		if not rospy.has_param(param_string):
 			default_acc = 1.0 # rad^2/s
@@ -624,7 +633,7 @@ class simple_script_server:
 
 			# use hardcoded point_time if no start_pos available
 			if start_pos != []:
-				point_time = self.calculate_point_time(start_pos, point, default_vel, default_acc)
+				point_time = self.calculate_point_time(start_pos, point, numpy.array(velocities), default_acc)
 			else:
 				point_time = 8*point_nr
 

--- a/cob_script_server/src/simple_script_server/simple_script_server.py
+++ b/cob_script_server/src/simple_script_server/simple_script_server.py
@@ -860,7 +860,7 @@ class simple_script_server:
 	# \param blocking Bool value to specify blocking behaviour.
 	#
 	# # throws error code 3 in case of invalid parameter_name vector
-	def move_rel(self, component_name, parameter_name, blocking=True):
+	def move_rel(self, component_name, parameter_name, blocking=True, speed_factor=1.0, urdf_vel=False, default_vel=None):
 		ah = action_handle("move_rel", component_name, parameter_name, blocking, self.parse)
 		if(self.parse):
 			return ah
@@ -932,7 +932,7 @@ class simple_script_server:
 				return ah
 			end_poses.append(end_pos)
 
-		return self.move_traj(component_name, end_poses, blocking)
+		return self.move_traj(component_name, end_poses, blocking, speed_factor=speed_factor, urdf_vel=urdf_vel, default_vel=default_vel)
 
 #------------------- LED section -------------------#
 	## Set the color of the cob_light component.

--- a/cob_script_server/src/simple_script_server/simple_script_server.py
+++ b/cob_script_server/src/simple_script_server/simple_script_server.py
@@ -381,11 +381,11 @@ class simple_script_server:
 	# \param component_name Name of the component.
 	# \param parameter_name Name of the parameter on the ROS parameter server.
 	# \param blocking Bool value to specify blocking behaviour.
-	def move(self,component_name,parameter_name,blocking=True, mode=None):
+	def move(self,component_name,parameter_name,blocking=True, mode=None, speed_factor=1.0):
 		if component_name == "base":
 			return self.move_base(component_name,parameter_name,blocking, mode)
 		else:
-			return self.move_traj(component_name,parameter_name,blocking)
+			return self.move_traj(component_name,parameter_name,blocking, speed_factor=speed_factor)
 
 	## Deals with movements of the base.
 	#
@@ -498,7 +498,7 @@ class simple_script_server:
 		return ah
 
 	## Parse and compose trajectory message
-	def compose_trajectory(self, component_name, parameter_name):
+	def compose_trajectory(self, component_name, parameter_name, speed_factor=1.0):
 		# get joint_names from parameter server
 		param_string = self.ns_global_prefix + "/" + component_name + "/joint_names"
 		if not rospy.has_param(param_string):
@@ -633,7 +633,7 @@ class simple_script_server:
 
 			# use hardcoded point_time if no start_pos available
 			if start_pos != []:
-				point_time = self.calculate_point_time(start_pos, point, numpy.array(velocities), default_acc)
+				point_time = self.calculate_point_time(start_pos, point, numpy.array(velocities)*speed_factor, default_acc)
 			else:
 				point_time = 8*point_nr
 
@@ -701,7 +701,7 @@ class simple_script_server:
 	# \param component_name Name of the component.
 	# \param parameter_name Name of the parameter on the ROS parameter server.
 	# \param blocking Bool value to specify blocking behaviour.
-	def move_traj(self,component_name,parameter_name,blocking):
+	def move_traj(self,component_name,parameter_name,blocking, speed_factor=1.0):
 		ah = action_handle("move", component_name, parameter_name, blocking, self.parse)
 		if(self.parse):
 			return ah
@@ -709,7 +709,7 @@ class simple_script_server:
 			ah.set_active()
 
 		rospy.loginfo("Move <<%s>> to <<%s>>",component_name,parameter_name)
-		(traj_msg, error_code) = self.compose_trajectory(component_name, parameter_name)
+		(traj_msg, error_code) = self.compose_trajectory(component_name, parameter_name, speed_factor=speed_factor)
 		if error_code != 0:
 			message = "Composing the trajectory failed with error: " + str(error_code)
 			ah.set_failed(error_code, message)

--- a/cob_script_server/src/simple_script_server/simple_script_server.py
+++ b/cob_script_server/src/simple_script_server/simple_script_server.py
@@ -654,16 +654,16 @@ class simple_script_server:
 			default_acc = numpy.array([default_acc for _ in start_pos])
 
 		try:
-			# d_max: Distance traveled in the move by each joint
-			d_max = numpy.abs(numpy.array(start_pos) - numpy.array(end_pos))
+			# dist: Distance traveled in the move by each joint
+			dist = numpy.abs(numpy.array(start_pos) - numpy.array(end_pos))
 
 			t1 = default_vel / default_acc  # Time needed for joints to accelerate to desired velocity
 			s1 = default_acc / 2.0 * t1**2  # Distance traveled during this time
 
-			t = numpy.zeros_like(d_max)
+			t = numpy.zeros_like(dist)
 
 			for i in range(len(start_pos)):
-				if 2 * s1[i] < d_max[i]:
+				if 2 * s1[i] < dist[i]:
 					# If we can accelerate and decelerate in less than the total distance, then:
 					# accelerate up to speed, travel at that speed for a bit and then decelerate, a three phase trajectory:
 					# with constant velocity phase (acc, const vel, dec)
@@ -677,7 +677,7 @@ class simple_script_server:
 					#  | /         \
 					#  o--------------->
 					#         t     d_max
-					s2 = d_max[i] - 2 * s1[i]
+					s2 = dist[i] - 2 * s1[i]
 					t2 = s2 / default_vel[i]
 					t[i] = 2 * t1[i] + t2
 				else:
@@ -686,7 +686,7 @@ class simple_script_server:
 					# 1st phase: accelerate from v=0 to v=default_vel with a=default_acc in t=t1
 					# 2nd phase: missing because distance is to short (we already reached the distance with the acc and dec phase)
 					# 3rd phase: deceleration (analog to 1st phase)
-					t[i] = numpy.sqrt(d_max[i] / default_acc[i])
+					t[i] = numpy.sqrt(dist[i] / default_acc[i])
 
 			# Instead of deciding per joint if we can do a three or two-phase trajectory,
 			# we can simply take the slowest joint of them all and select that.

--- a/cob_script_server/src/simple_script_server/simple_script_server.py
+++ b/cob_script_server/src/simple_script_server/simple_script_server.py
@@ -597,29 +597,43 @@ class simple_script_server:
 
 		param_string = self.ns_global_prefix + "/" + component_name + "/default_vel"
 		if not rospy.has_param(param_string):
-			default_vel = 0.1 # rad/s
-			rospy.logwarn("parameter %s does not exist on ROS Parameter Server, using default of %f [rad/sec].",param_string,default_vel)
+			default_vel = numpy.array([0.1 for _ in start_pos]) # rad/s
+			rospy.logwarn("parameter %s does not exist on ROS Parameter Server, using default_vel {} [rad/sec].".format(param_string,default_vel))
 		else:
-			default_vel = rospy.get_param(param_string)
+			param_vel = rospy.get_param(param_string)
+			if (type(param_vel) is float) or (type(param_vel) is int):
+				default_vel = numpy.array([param_vel for _ in start_pos])
+			elif (type(param_vel) is list) and (len(param_vel) == len(start_pos)) and all(((type(item) is float) or (type(item) is int)) for item in param_vel):
+				default_vel = param_vel
+			else:
+				default_vel = numpy.array([0.1 for _ in start_pos]) # rad/s
+				rospy.logwarn("parameter %s has wrong format (must be float/int or list of float/int), using default_vel {} [rad/sec].".format(param_string,default_vel))
 
 		if urdf_vel:
 			robot_urdf = URDF.from_parameter_server()
 			velocities = []
-			for joint_name in joint_names:
+			for idx, joint_name in enumerate(joint_names):
 				try:
 					velocities.append(robot_urdf.joint_map[joint_name].limit.velocity)
 				except KeyError:
-					velocities.append(default_vel)
+					velocities.append(default_vel[i])
 		else:
-			velocities = [default_vel for _ in joint_names]
+			velocities = list(default_vel)
 		rospy.loginfo("Velocities are: {}".format(velocities))
 
 		param_string = self.ns_global_prefix + "/" + component_name + "/default_acc"
 		if not rospy.has_param(param_string):
-			default_acc = 1.0 # rad^2/s
-			rospy.logwarn("parameter %s does not exist on ROS Parameter Server, using default of %f [rad^2/sec].",param_string,default_acc)
+			default_acc = numpy.array([1.0 for _ in start_pos]) # rad^2/s
+			rospy.logwarn("parameter %s does not exist on ROS Parameter Server, using default_acc {} [rad^2/sec].".format(param_string,default_acc))
 		else:
-			default_acc = rospy.get_param(param_string)
+			param_acc = rospy.get_param(param_string)
+			if (type(param_acc) is float) or (type(param_acc) is int):
+				default_acc = numpy.array([param_acc for _ in start_pos])
+			elif (type(param_acc) is list) and (len(param_acc) == len(start_pos)) and all(((type(item) is float) or (type(item) is int)) for item in param_acc):
+				default_acc = param_acc
+			else:
+				default_acc = numpy.array([0.1 for _ in start_pos]) # rad/s
+				rospy.logwarn("parameter %s has wrong format (must be float/int or list of float/int), using default_acc {} [rad^2/sec].".format(param_string,default_acc))
 
 		for point in traj:
 			point_nr = point_nr + 1

--- a/cob_script_server/src/simple_script_server/simple_script_server.py
+++ b/cob_script_server/src/simple_script_server/simple_script_server.py
@@ -24,6 +24,7 @@ import thread
 import commands
 import math
 import threading
+import numpy
 
 # graph includes
 import pygraphviz as pgv


### PR DESCRIPTION
implements https://github.com/mojin-robotics/cob4/issues/1277#issuecomment-552875855

this pr (is supposed to) implement the following behavior:
```
sss.move("torso","front") -> current behavior: motion uses `default_vel` from yaml - can be float of list of float
sss.move("torso","front",speed_factor=0.5) -> uses half the speed of `default_vel` from yaml (s.o.)
sss.move("torso","front",speed_factor=2.0) -> uses twice the speed of `default_vel` from yaml (s.o.), but fails in case one joint vel exceeds the respective limit from urdf
sss.move("torso","front",speed_factor=0.0) -> will fail due to zero vel
sss.move("torso","front",speed_factor=-1.0) -> will fail due to negative vel
sss.move("torso","front",urdf_vel=true) -> uses vel limits from urdf
sss.move("torso","front",speed_factor=0.5,urdf_vel=true) -> uses half the vel limits from urdf
sss.move("torso","front",speed_factor=2.0,urdf_vel=true) -> will fail due to exceeding limits
sss.move("torso","front",default_vel=1.0) -> overwrites default_vel from yaml
sss.move("torso","front",default_vel=[n*1.0]) -> overwrites default_vel from yaml
sss.move("torso","front",default_vel=[n!=m*1.0]) -> will fail due to dimension mismatch
sss.move("torso","front",urdf_vel=true,default_vel=1.0) -> will fail due to invalid arguments
```

@LoyVanBeek can you carefully review (you could do it commit-by-commit), test and merge this into your feature branch?

@floweisshardt and @fmessmer will then test final version of https://github.com/ipa320/cob_command_tools/pull/259 on hw again