### PR TITLE
add minimal init node for joystick

### DIFF
--- a/cob_teleop/ros/src/joy_init
+++ b/cob_teleop/ros/src/joy_init
@@ -1,4 +1,19 @@
 #!/usr/bin/env python
+#
+# Copyright 2017 Fraunhofer Institute for Manufacturing Engineering and Automation (IPA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import rospy
 from sensor_msgs.msg import Joy
 from std_srvs.srv import Trigger, TriggerRequest

--- a/cob_teleop/ros/src/joy_init
+++ b/cob_teleop/ros/src/joy_init
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+import rospy
+from sensor_msgs.msg import Joy
+from std_srvs.srv import Trigger, TriggerRequest
+
+class JoyInit(object):
+  def __init__(self):
+
+    rospy.wait_for_service("/base/driver/init")
+    self.init_client = rospy.ServiceProxy("/base/driver/init", Trigger)
+    rospy.wait_for_service("/base/driver/recover")
+    self.recover_client = rospy.ServiceProxy("/base/driver/recover", Trigger)
+
+    self.last_init = rospy.Time()
+    self.initialized = False
+    self.joy_subscriber = rospy.Subscriber("/joy", Joy, self.joy_callback)
+
+
+
+  def joy_callback(self, joy_message):
+    if (rospy.Time.now() - self.last_init)  < rospy.Duration(1):
+      rospy.logdebug("still cooldown")
+      return
+    if joy_message.buttons[4] and joy_message.buttons[5] and joy_message.buttons[9]:
+      if not self.initialized:
+        rospy.loginfo("Init base")
+
+        response = self.init_client(TriggerRequest())
+        if not response.success:
+          rospy.logerr("Init base failed: {}".format(response.message))
+          return
+        self.initialized = True
+        self.last_init = rospy.Time.now()
+
+      else:
+        rospy.loginfo("Recover base")
+
+        response = self.recover_client(TriggerRequest())
+        if not response.success:
+          rospy.logerr("Recover base failed: {}".format(response.message))
+          return
+        self.last_init = rospy.Time.now()
+      
+
+ 
+
+
+if __name__ == "__main__":
+    rospy.init_node("joystick_init")
+    ji = JoyInit()
+    rospy.spin()


### PR DESCRIPTION
I'm sure this will lead to discussions.

Since the Simple Scriptserver is not used anymore by us and there were issues with melodic, we needed a new way to "init and recover" with the joystick. This node is only used for init and recover and doesn't introduce new dependencies. imho cob_teleop would be a place for this node, but since it is a duplication of functionality it's not that nice