### PR TITLE
publish move_base goal without global /map

### DIFF
--- a/cob_script_server/src/simple_script_server/simple_script_server.py
+++ b/cob_script_server/src/simple_script_server/simple_script_server.py
@@ -451,7 +451,7 @@ class simple_script_server:
 		# convert to pose message
 		pose = PoseStamped()
 		pose.header.stamp = rospy.Time.now()
-		pose.header.frame_id = "/map"
+		pose.header.frame_id = "map"
 		pose.pose.position.x = param[0]
 		pose.pose.position.y = param[1]
 		pose.pose.position.z = 0.0


### PR DESCRIPTION
Using `map`  for move_base/goal because `/map` is no longer supported in melodic. 

fixes https://github.com/mojin-robotics/mojin_atf/pull/1#pullrequestreview-343464334