### PR TITLE
Allow scripts to await for ScriptableActionServers to be connected

### DIFF
--- a/scenario_test_tools/src/scenario_test_tools/scriptable_action_server.py
+++ b/scenario_test_tools/src/scenario_test_tools/scriptable_action_server.py
@@ -58,6 +58,13 @@ class ScriptableActionServer(ScriptableBase):
         self._as.register_goal_callback(self._execute_cb)
         self._as.register_preempt_callback(self._preempt_cb)
 
+    def __repr__(self):
+        return "ScriptableActionServer('{}')".format(self._name)
+
+    @property
+    def connected(self):
+        return self._as.action_server.goal_sub.get_num_connections() >= 1
+
     def start(self):
         """
         Start the action server and thus listen to goals

--- a/scenario_test_tools/src/scenario_test_tools/scriptable_base.py
+++ b/scenario_test_tools/src/scenario_test_tools/scriptable_base.py
@@ -70,6 +70,10 @@ class ScriptableBase(object):
 
         self._pre_reply_callbacks = []
 
+    @property
+    def name(self):
+        return self._name
+
     def stop(self):
         """
         If the process is blocked by waiting for some Events to be set, stop sets those Events.

--- a/scenario_test_tools/src/scenario_test_tools/scriptable_move_base.py
+++ b/scenario_test_tools/src/scenario_test_tools/scriptable_move_base.py
@@ -23,6 +23,16 @@ from scenario_test_tools.scriptable_action_server import ScriptableActionServer
 from scenario_test_tools.util import countdown_sleep, round_tuple
 
 
+def format_move_base_goal(mbg):
+    roll, pitch, yaw = tf.transformations.euler_from_quaternion(
+        [mbg.target_pose.pose.orientation.x, mbg.target_pose.pose.orientation.y, mbg.target_pose.pose.orientation.z,
+         mbg.target_pose.pose.orientation.w])
+    return "MoveBase to: (x={x}, y={y}, yaw={yaw})".format(
+        x=mbg.target_pose.pose.position.x,
+        y=mbg.target_pose.pose.position.y,
+        yaw=yaw)
+
+
 class ScriptableMoveBase(ScriptableActionServer):
     def __init__(self, name, action_type, goal_formatter=format, result_formatter=format, default_result=None, default_result_delay=0, pub_transform=True):
         ScriptableActionServer.__init__(self,

--- a/scenario_test_tools/src/scenario_test_tools/scriptable_service_server.py
+++ b/scenario_test_tools/src/scenario_test_tools/scriptable_service_server.py
@@ -37,6 +37,9 @@ class ScriptableServiceServer(ScriptableBase):
 
         self._srv = rospy.Service(name, service_type, self._execute_cb)
 
+    def __repr__(self):
+        return "ScriptableServiceServer('{}')".format(self._name)
+
     def stop(self):
         super(ScriptableServiceServer, self).stop()
 


### PR DESCRIPTION
Scripts using `ScriptableActionServer`s may need to wait until all of their clients are up and ready-to-run before actually starting the test. This PR helps that. 