### PR TITLE
[noetic] cob_command_gui migration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ env:
   matrix:
     - ROS_DISTRO=kinetic
     - ROS_DISTRO=melodic
-    - ROS_DISTRO=noetic TARGET_WORKSPACE='. -cob_command_tools/cob_command_gui -cob_command_tools/cob_command_tools' UPSTREAM_WORKSPACE=.travis.rosinstall.noetic PYLINT2_CHECK=true PYLINT3_CHECK=false  # noetic is python3 only, i.e. only pylint command exists which is used as executable in PYLINT2_CHECK
+    - ROS_DISTRO=noetic UPSTREAM_WORKSPACE=.travis.rosinstall.noetic PYLINT2_CHECK=true PYLINT3_CHECK=false  # noetic is python3 only, i.e. only pylint command exists which is used as executable in PYLINT2_CHECK
 install:
   - git clone --quiet --depth 1 https://github.com/fmessmer/industrial_ci.git .industrial_ci -b master_pylint
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
     - CATKIN_LINT_ARGS='--ignore description_boilerplate --ignore target_name_collision'
     - CMAKE_ARGS=-DCMAKE_BUILD_TYPE=Release
     - NOT_TEST_DOWNSTREAM=true
-    - PYLINT_ARGS="--output-format=parseable --errors-only --ignored-modules=catkin_pkg,cv2,itertools,gtk,gtk.gdk,mechanize,numpy,paramiko,psutil,pygraphviz,pygtk,python_qt_binding,python_qt_binding.QtCore,requests,setuptools"
+    - PYLINT_ARGS="--output-format=parseable --errors-only --ignored-modules=catkin_pkg,cv2,itertools,gi,gtk,gtk.gdk,mechanize,numpy,paramiko,psutil,pygraphviz,pygtk,python_qt_binding,python_qt_binding.QtCore,requests,setuptools"
     - PYLINT2_CHECK=true
     - PYLINT3_CHECK=true
     - ROS_REPO=ros

--- a/cob_command_gui/package.xml
+++ b/cob_command_gui/package.xml
@@ -22,8 +22,8 @@
 
   <exec_depend>cob_msgs</exec_depend>
   <exec_depend>cob_script_server</exec_depend>
-  <exec_depend>python-gtk2</exec_depend>
-  <exec_depend>python-pygraphviz</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-gi</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-gi</exec_depend>
   <exec_depend>roslib</exec_depend>
   <exec_depend>rospy</exec_depend>
 

--- a/cob_command_gui/src/knoeppkes.py
+++ b/cob_command_gui/src/knoeppkes.py
@@ -16,8 +16,10 @@
 
 
 from threading import Thread
-import pygtk
-pygtk.require('2.0')
+from gi import pygtkcompat
+pygtkcompat.enable()
+pygtkcompat.enable_gtk(version='3.0')
+
 import gtk
 import os
 import sys
@@ -162,18 +164,18 @@ class GtkGeneralPanel(gtk.Frame):
   def setEMStop(self, em):
     if(em):
       #print("Emergency Stop Active")
-      gtk.threads_enter()
+      gtk.gdk.threads_enter()
       self.status_image.set_from_file(roslib.packages.get_pkg_dir("cob_command_gui") + "/common/files/icons/error.png")
       self.status_label.set_text("EM Stop !")
-      gtk.threads_leave()
+      gtk.gdk.threads_leave()
       if(self.em_stop == False):
         self.em_stop = True
     else:
       #print("Status OK")
       self.status_image.set_from_file(roslib.packages.get_pkg_dir("cob_command_gui") + "/common/files/icons/ok.png")
-      gtk.threads_enter()
+      gtk.gdk.threads_enter()
       self.status_label.set_text("Status OK")
-      gtk.threads_leave()
+      gtk.gdk.threads_leave()
       if(self.em_stop == True):
         self.em_stop = False
 


### PR DESCRIPTION
fixes https://github.com/ipa320/cob_command_tools/issues/285
ref mojin-robotics/cob4#1486

pygobject offers a compatibility layer for pygtk2. see: https://pygobject.readthedocs.io/en/latest/guide/porting.html

In the long run, it would be preferred switching to plain pygobject or qt. This should make travis green, but the execution tests on a noetic machine are still missing. Works on melodic.