### PR TITLE
commenting dependency python3-mechanize

### DIFF
--- a/cob_monitoring/package.xml
+++ b/cob_monitoring/package.xml
@@ -33,7 +33,7 @@
   <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-paramiko</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-paramiko</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-mechanize</exec_depend>
-  <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-mechanize</exec_depend>
+  <!--exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-mechanize</exec_depend--> <!-- commenting as python3-mechanize is not available for debian:buster (see https://github.com/ipa320/cob_command_tools/issues/289) -->
   <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-psutil</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-psutil</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-requests</exec_depend>


### PR DESCRIPTION
workaround for #289 
`mechanize` is only used in `cob_monitoring/ddwrt.py` which is not really used anymore anyway
i.e. it's only included in `cob_robots/cob_bringup/tools/wifi_monitor.launch` (https://github.com/ipa320/cob_robots/blob/kinetic_dev/cob_bringup/tools/wifi_monitor.launch#L8) which only has a **commented** appearance in `raw3-1.xml` (https://github.com/ipa320/cob_robots/blob/kinetic_dev/cob_bringup/robots/raw3-1.xml#L32-L34)