### PR TITLE
ROS_PYTHON_VERSION conditional dependency for python-six

### DIFF
--- a/cob_script_server/package.xml
+++ b/cob_script_server/package.xml
@@ -39,7 +39,8 @@
   <exec_depend>move_base_msgs</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-pygraphviz</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-pygraphviz</exec_depend>
-  <exec_depend>python-six</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-six</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-six</exec_depend>
   <exec_depend>rospy</exec_depend>
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>std_srvs</exec_depend>


### PR DESCRIPTION
Introspecting Python 2 dependencies in ROS Noetic, found that this package depends on `python-six` instead of its python3 counterpart.

This PR makes the dependency conditional on the ROS_PYTHON_VERSION.
SImilar to https://github.com/ipa320/cob_command_tools/pull/286

This is a semi-automated PR that has not been tested