### PR TITLE
fix deprecation warning

### DIFF
--- a/cob_monitoring/src/cpu_monitor.py
+++ b/cob_monitoring/src/cpu_monitor.py
@@ -579,7 +579,7 @@ class CPUMonitor():
 
         for idx, label in enumerate(rdata['labels']):
             np_array = np.array(sdata[idx])
-            if np_array.dtype == np.object:
+            if np_array.dtype == object:
                 rospy.logwarn("Data from NetData malformed")
                 return None
             d[label] = np_array


### PR DESCRIPTION
fixes deprecation warning:
```
/u/robot/git/robot_ws/src/cob_command_tools/cob_monitoring/src/cpu_monitor.py:582: DeprecationWarning: `np.object` is a deprecated alias for the builtin `object`. To silence this warnin
g, use `object` by itself. Doing this will not modify any behavior and is safe. 
Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
  if np_array.dtype == np.object:
```