### PR TITLE
fix cob_monitoring

### DIFF
--- a/cob_monitoring/src/cpu_monitor.py
+++ b/cob_monitoring/src/cpu_monitor.py
@@ -18,6 +18,7 @@
 
 
 import sys, os, time
+import traceback
 import subprocess
 import string
 import socket
@@ -553,7 +554,7 @@ class CPUMonitor():
         except Exception as e:
             diag_level = DiagnosticStatus.ERROR
             diag_msg = 'CPU Usage Exception'
-            diag_vals = [ KeyValue(key = 'Exception', value = str(e)) ]
+            diag_vals = [ KeyValue(key = 'Exception', value = str(e)), KeyValue(key = 'Traceback', value = str(traceback.format_exc())) ]
 
         return diag_vals, diag_msg, diag_level
 

--- a/cob_monitoring/src/cpu_monitor.py
+++ b/cob_monitoring/src/cpu_monitor.py
@@ -203,7 +203,7 @@ class CPUMonitor():
         except Exception as e:
             diag_level = DiagnosticStatus.ERROR
             diag_msgs = [ 'IPMI Exception' ]
-            diag_vals = [ KeyValue(key = 'Exception', value = str(e)) ]
+            diag_vals = [ KeyValue(key = 'Exception', value = str(e)), KeyValue(key = 'Traceback', value = str(traceback.format_exc())) ]
 
         return diag_vals, diag_msgs, diag_level
 
@@ -256,7 +256,7 @@ class CPUMonitor():
         except Exception as e:
             diag_level = DiagnosticStatus.ERROR
             diag_msgs = [ 'Core Temp Exception' ]
-            diag_vals = [ KeyValue(key = 'Exception', value = str(e)) ]
+            diag_vals = [ KeyValue(key = 'Exception', value = str(e)), KeyValue(key = 'Traceback', value = str(traceback.format_exc())) ]
 
         return diag_vals, diag_msgs, diag_level
 
@@ -341,7 +341,7 @@ class CPUMonitor():
         except Exception as e:
             diag_level = DiagnosticStatus.ERROR
             diag_msgs = [ 'Clock Speed Exception' ]
-            diag_vals = [ KeyValue(key = 'Exception', value = str(e)) ]
+            diag_vals = [ KeyValue(key = 'Exception', value = str(e)), KeyValue(key = 'Traceback', value = str(traceback.format_exc())) ]
 
         return diag_vals, diag_msgs, diag_level
 
@@ -393,7 +393,7 @@ class CPUMonitor():
         except Exception as e:
             diag_level = DiagnosticStatus.ERROR
             diag_msg = 'Uptime Exception'
-            diag_vals = [ KeyValue(key = 'Exception', value = str(e)) ]
+            diag_vals = [ KeyValue(key = 'Exception', value = str(e)), KeyValue(key = 'Traceback', value = str(traceback.format_exc())) ]
 
         return diag_vals, diag_msg, diag_level
 
@@ -463,7 +463,7 @@ class CPUMonitor():
         except Exception as e:
             diag_level = DiagnosticStatus.ERROR
             diag_msg = 'Memory Usage Exception'
-            diag_vals = [ KeyValue(key = 'Exception', value = str(e)) ]
+            diag_vals = [ KeyValue(key = 'Exception', value = str(e)), KeyValue(key = 'Traceback', value = str(traceback.format_exc())) ]
 
         return diag_vals, diag_msg, diag_level
 
@@ -713,6 +713,7 @@ class CPUMonitor():
             return devices
         except Exception as e:
             rospy.logerr('Exception finding temp vals: {}'.format(e))
+            rospy.logerr('Trackeback: \n{}'.format(traceback.format_exc()))
             return []
 
 

--- a/cob_monitoring/src/cpu_monitor.py
+++ b/cob_monitoring/src/cpu_monitor.py
@@ -546,7 +546,7 @@ class CPUMonitor():
             # Check the number of cores if self._num_cores > 0, #4850
             if self._num_cores > 0 and self._num_cores != num_cores:
                 diag_level = DiagnosticStatus.ERROR
-                diag_msg = 'Incorrect number of CPU cores: Expected %d, got %d. Computer may have not booted properly.' % self._num_cores, num_cores
+                diag_msg = 'Incorrect number of CPU cores: Expected {}, got {}. Computer may have not booted properly.'.format(self._num_cores, num_cores)
                 return diag_vals, diag_msg, diag_level
 
             diag_msg = load_dict[diag_level]

--- a/cob_monitoring/src/hd_monitor.py
+++ b/cob_monitoring/src/hd_monitor.py
@@ -18,6 +18,7 @@
 
 
 import sys, os, time
+import traceback
 import subprocess
 import socket
 
@@ -105,7 +106,7 @@ class hd_monitor():
         except Exception as e:
             diag_level = DiagnosticStatus.ERROR
             diag_msg = 'HD IO Exception'
-            diag_vals = [ KeyValue(key = 'Exception', value = str(e)) ]
+            diag_vals = [ KeyValue(key = 'Exception', value = str(e)), KeyValue(key = 'Traceback', value = str(traceback.format_exc())) ]
 
         self._io_stat.values = diag_vals
         self._io_stat.message = diag_msg
@@ -181,7 +182,7 @@ class hd_monitor():
         except Exception as e:
             diag_level = DiagnosticStatus.ERROR
             diag_message = 'HD Usage Exception'
-            diag_vals = [ KeyValue(key = 'Exception', value = str(e)) ]
+            diag_vals = [ KeyValue(key = 'Exception', value = str(e)), KeyValue(key = 'Traceback', value = str(traceback.format_exc())) ]
 
         self._usage_stat.values = diag_vals
         self._usage_stat.message = diag_message

--- a/cob_monitoring/src/net_monitor.py
+++ b/cob_monitoring/src/net_monitor.py
@@ -253,6 +253,7 @@ class NetMonitor(object):
             rospy.logerr(traceback.format_exc())
             net_msg = 'Network Usage Check Error'
             values.append(KeyValue(key=net_msg, value=str(e)))
+            values.append(KeyValue(key='Traceback', value=str(traceback.format_exc())))
             level = DiagnosticStatus.ERROR
         return level, net_msg, values
 

--- a/cob_monitoring/src/ntp_monitor.py
+++ b/cob_monitoring/src/ntp_monitor.py
@@ -17,6 +17,7 @@
 
 
 import sys
+import traceback
 import socket
 from subprocess import Popen, PIPE
 import time
@@ -90,7 +91,7 @@ class NtpMonitor():
         except Exception as e:
             stat.level = DiagnosticStatus.ERROR
             stat.message = 'ntpdate Exception'
-            stat.values = [ KeyValue(key = 'Exception', value = str(e)) ]
+            stat.values = [ KeyValue(key = 'Exception', value = str(e)), KeyValue(key = 'Traceback', value = str(traceback.format_exc())) ]
 
         self.msg = DiagnosticArray()
         self.msg.header.stamp = rospy.get_rostime()

--- a/cob_monitoring/src/wlan_monitor.py
+++ b/cob_monitoring/src/wlan_monitor.py
@@ -18,6 +18,7 @@ import getpass
 import re
 import os
 import sys
+import traceback
 from subprocess import Popen, PIPE
 import paramiko
 
@@ -84,6 +85,7 @@ class IwConfigLocal(IwConfigParser):
             except Exception as e:
                 rospy.logerr("IwConfigLocal update exception: %s" %e)
                 self.stat.values.append(KeyValue(key = 'update exception', value = str(e)))
+                self.stat.values.append(KeyValue(key = 'Traceback', value = str(traceback.format_exc())))
 
 class IwConfigSSH(IwConfigParser):
     def __init__(self, hostname, user, password):
@@ -121,6 +123,7 @@ class IwConfigSSH(IwConfigParser):
             except Exception as e:
                 rospy.logerr("IwConfigSSH update exception: %s" %e)
                 self.stat.values.append(KeyValue(key = 'update exception', value = str(e)))
+                self.stat.values.append(KeyValue(key = 'Traceback', value = str(traceback.format_exc())))
 
 class WlanMonitor():
     def __init__(self):
@@ -150,7 +153,7 @@ class WlanMonitor():
                 rospy.logerr(msg)
                 self._wlan_stat.level = DiagnosticStatus.ERROR
                 self._wlan_stat.message = msg
-                self._wlan_stat.values = [ KeyValue(key = 'Exception', value = str(e)) ]
+                self._wlan_stat.values = [ KeyValue(key = 'Exception', value = str(e)), KeyValue(key = 'Traceback', value = str(traceback.format_exc())) ]
                 self.msg.status = [self._wlan_stat]
                 return
 


### PR DESCRIPTION
- fix string format
- add exception traceback

:point_right: use `format` for all strings
:point_right: add traceback to all exceptions