### PR TITLE
sleep for 1 second after unsuccessful try to initialize

### DIFF
--- a/cob_helper_tools/scripts/auto_init.py
+++ b/cob_helper_tools/scripts/auto_init.py
@@ -58,6 +58,7 @@ class AutoInit():
             handle = sss.init(component)
             if not (handle.get_error_code() == 0):
               rospy.logerr("[auto_init]: Could not initialize %s. Retrying...(%s of %s)", component, str(retries), str(self.max_retries))
+              rospy.sleep(1.0)
             else:
               rospy.loginfo("[auto_init]: Component %s initialized successfully", component)
               break


### PR DESCRIPTION
fixes too-fast retrying to initialize:
```
[ERROR] [1639409014.359879]: [auto_init]: Could not initialize arm. Retrying...(25 of 50)                                                                                
[ERROR] [1639409014.385192]: ...response of <<init>> of <<arm>> not successfull,                                                                                         
 error: Could not send robot programm. Robot Mode is: 4                                                                                                                  
[ERROR] [1639409014.387510]: [auto_init]: Could not initialize arm. Retrying...(26 of 50)
[ERROR] [1639409014.413760]: ...response of <<init>> of <<arm>> not successfull,    
 error: Could not send robot programm. Robot Mode is: 4                                                                                                                  
[ERROR] [1639409014.415574]: [auto_init]: Could not initialize arm. Retrying...(27 of 50)
```
(my assumption is that that's the reason why we need to restart the bringup after shutdown to be able to use the arm)