### PR TITLE
allow multiple cob_consoles to run in parallel

### DIFF
--- a/cob_script_server/src/cob_console_node
+++ b/cob_script_server/src/cob_console_node
@@ -20,4 +20,4 @@ from simple_script_server import simple_script_server
 sss = simple_script_server()
 
 if __name__ == "__main__":
-    rospy.init_node("cob_console")
+    rospy.init_node("cob_console", anonymous=True)


### PR DESCRIPTION
so far there could only be one instance of cob_console. If another one was started the previous one was shutdown by ROS ("new node registered with same name"). This PR add an anonymous node handle, which allows multiple cob_console to exist in parallel.