### PR TITLE
fixing crashed thread if netdata data was malformed and make netdata module name for core temps in api calls configurable

### DIFF
--- a/cob_monitoring/src/cpu_monitor.py
+++ b/cob_monitoring/src/cpu_monitor.py
@@ -34,6 +34,7 @@ stat_dict = { DiagnosticStatus.OK: 'OK', DiagnosticStatus.WARN: 'Warning', Diagn
 class CPUMonitor():
     def __init__(self, hostname, diag_hostname):
         self._check_core_temps = rospy.get_param('~check_core_temps', False)
+        self._netdata_module_name_core_temps = rospy.get_param('~netdata_module_name_core_temps', 'sensors.coretemp_isa_0000_temperature')
 
         self._core_load_warn = rospy.get_param('~core_load_warn', 90)
         self._core_load_error = rospy.get_param('~core_load_error', 110)
@@ -89,7 +90,7 @@ class CPUMonitor():
         diag_level = DiagnosticStatus.OK
 
         try:
-            netdata_core_temp, error = query_netdata('sensors.coretemp_isa_0000_temperature', interval)
+            netdata_core_temp, error = query_netdata(self._netdata_module_name_core_temps, interval)
             if not netdata_core_temp:
                 diag_level = DiagnosticStatus.ERROR
                 diag_msgs = [ 'Core Temp Error' ]
@@ -189,11 +190,11 @@ class CPUMonitor():
             netdata_cpu_load, error = query_netdata('system.load', interval)
             if not netdata_cpu_load:
                 diag_level = DiagnosticStatus.ERROR
-                diag_msgs = [ 'Load Error' ]
+                diag_msg = 'Load Error'
                 diag_vals = [ KeyValue(key = 'Load Error', value = 'Could not fetch data from netdata'),
                               KeyValue(key = 'Output', value = netdata_cpu_load),
                               KeyValue(key = 'Error', value= error) ]
-                return (diag_vals, diag_msgs, diag_level)
+                return (diag_vals, diag_msg, diag_level)
 
             del netdata_cpu_load['time']
 

--- a/cob_monitoring/src/netdata_tools/netdata_tools.py
+++ b/cob_monitoring/src/netdata_tools/netdata_tools.py
@@ -40,9 +40,10 @@ def query_netdata(chart, after):
 
     for idx, label in enumerate(rdata['labels']):
         np_array = numpy.array(sdata[idx])
-        if np_array.dtype == object:
+        if np_array.dtype == object or (np_array == None).any():
             msg = "Data from NetData malformed: {}".format(label)
             rospy.logwarn(msg)
+            rospy.logwarn('... malformed data for Label <{}>: {}'.format(label, np_array))
             return None, msg
         d[label] = np_array
 


### PR DESCRIPTION
there are in basic 3 problems on the netdata metrics:
* one bug in the code where the diagnostic thread crashes  on malformed data from netdata (fixed for load errors)
* sensor module name change (for temperature) on newer netdata versions (can now be configured)
  * old: `sensors.coretemp_isa_0000_temperature` new: `sensors.coretemp-isa-0000_temperature`
  * should maybe automatic changed regarding to netdata version that is also available by api call to http://127.0.0.1:19999/api/v1/info
* possible api bug (but at least a different behaivior) in newer versions (missing thread synchronization?) of netdata [**not solved** here but causes the 2 other problems, maybe as followup or as issue in [netdata repo](https://github.com/netdata/netdata)]
![20220622_134422_Selection_001](https://user-images.githubusercontent.com/4059009/175022108-96cb72b8-35d7-47c4-89f4-02da24291ad2.jpg)