### PR TITLE
Fix/netdata based diagnostics

### DIFF
--- a/cob_monitoring/src/cpu_monitor.py
+++ b/cob_monitoring/src/cpu_monitor.py
@@ -34,8 +34,6 @@ stat_dict = { DiagnosticStatus.OK: 'OK', DiagnosticStatus.WARN: 'Warning', Diagn
 class CPUMonitor():
     def __init__(self, hostname, diag_hostname):
         self._check_core_temps = rospy.get_param('~check_core_temps', False)
-        self._netdata_module_name_core_temps = rospy.get_param('~netdata_module_name_core_temps', 'sensors.coretemp_isa_0000_temperature')
-
         self._core_load_warn = rospy.get_param('~core_load_warn', 90)
         self._core_load_error = rospy.get_param('~core_load_error', 110)
         self._load1_threshold = rospy.get_param('~load1_threshold', 5.0)
@@ -90,7 +88,14 @@ class CPUMonitor():
         diag_level = DiagnosticStatus.OK
 
         try:
-            netdata_core_temp, error = query_netdata(self._netdata_module_name_core_temps, interval)
+            # _ vs -
+            netdata_module_name_core_temps = ['sensors.coretemp_isa_0000_temperature',
+                                              'sensors.coretemp-isa-0000_temperature']
+            for name in netdata_module_name_core_temps:
+                netdata_core_temp, error = query_netdata(name, interval)
+                if netdata_core_temp:
+                    break
+
             if not netdata_core_temp:
                 diag_level = DiagnosticStatus.ERROR
                 diag_msgs = [ 'Core Temp Error' ]

--- a/cob_monitoring/src/cpu_monitor.py
+++ b/cob_monitoring/src/cpu_monitor.py
@@ -34,6 +34,7 @@ stat_dict = { DiagnosticStatus.OK: 'OK', DiagnosticStatus.WARN: 'Warning', Diagn
 class CPUMonitor():
     def __init__(self, hostname, diag_hostname):
         self._check_core_temps = rospy.get_param('~check_core_temps', False)
+        self._netdata_module_name_core_temps = rospy.get_param('~netdata_module_name_core_temps', 'sensors.coretemp_isa_0000_temperature')
 
         self._core_load_warn = rospy.get_param('~core_load_warn', 90)
         self._core_load_error = rospy.get_param('~core_load_error', 110)
@@ -89,7 +90,7 @@ class CPUMonitor():
         diag_level = DiagnosticStatus.OK
 
         try:
-            netdata_core_temp, error = query_netdata('sensors.coretemp_isa_0000_temperature', interval)
+            netdata_core_temp, error = query_netdata(self._netdata_module_name_core_temps, interval)
             if not netdata_core_temp:
                 diag_level = DiagnosticStatus.ERROR
                 diag_msgs = [ 'Core Temp Error' ]
@@ -189,11 +190,11 @@ class CPUMonitor():
             netdata_cpu_load, error = query_netdata('system.load', interval)
             if not netdata_cpu_load:
                 diag_level = DiagnosticStatus.ERROR
-                diag_msgs = [ 'Load Error' ]
+                diag_msg = 'Load Error'
                 diag_vals = [ KeyValue(key = 'Load Error', value = 'Could not fetch data from netdata'),
                               KeyValue(key = 'Output', value = netdata_cpu_load),
                               KeyValue(key = 'Error', value= error) ]
-                return (diag_vals, diag_msgs, diag_level)
+                return (diag_vals, diag_msg, diag_level)
 
             del netdata_cpu_load['time']
 

--- a/cob_monitoring/src/netdata_tools/netdata_tools.py
+++ b/cob_monitoring/src/netdata_tools/netdata_tools.py
@@ -40,9 +40,10 @@ def query_netdata(chart, after):
 
     for idx, label in enumerate(rdata['labels']):
         np_array = numpy.array(sdata[idx])
-        if np_array.dtype == object:
+        if np_array.dtype == object or (np_array == None).any():
             msg = "Data from NetData malformed: {}".format(label)
             rospy.logwarn(msg)
+            rospy.logwarn('... malformed data for Label <{}>: {}'.format(label, np_array))
             return None, msg
         d[label] = np_array
 


### PR DESCRIPTION
 - fixes https://github.com/mojin-robotics/cob4/issues/2533

Extends https://github.com/ipa320/cob_command_tools/pull/320
- with trying both spellings for `sensors.coretemp_isa_0000_temperature`, one with hyphens too
- Split `system.load` checking away from uptime checks

When the `load1`, `load5` or `load15` has a `null` value, we cannot parse and and the diagnostics show an error. 
It should be possible to remove these values altogether when such an error occurs and thus quietly drop the info. 
Not sure if that is preferable over  showing an error?