### PR TITLE
[kevin] disable unsupported algorithms of linksys router

### DIFF
--- a/cob_monitoring/package.xml
+++ b/cob_monitoring/package.xml
@@ -32,6 +32,8 @@
   <exec_depend>ifstat</exec_depend>
   <exec_depend>ipmitool</exec_depend>
   <exec_depend>ntpdate</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-packaging</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-packaging</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-paramiko</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-paramiko</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-mechanize</exec_depend>

--- a/cob_monitoring/src/wlan_monitor.py
+++ b/cob_monitoring/src/wlan_monitor.py
@@ -100,7 +100,12 @@ class IwConfigSSH(IwConfigParser):
         self.ssh.load_system_host_keys()
         ssh_key_file   = os.getenv("HOME")+'/.ssh/id_rsa.pub'
         self.ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())# no known_hosts error
-        self.ssh.connect(str(hostname), username=user, key_filename=ssh_key_file) # no passwd needed
+        self.ssh.connect(
+            str(hostname),
+            username=user,
+            key_filename=ssh_key_file,
+            disabled_algorithms={"pubkeys": ["rsa-sha2-256", "rsa-sha2-512"]}
+        ) # no passwd needed
         #self.ssh.connect(str(hostname), username=user, password=password)
 
         self.interfaces = []

--- a/cob_monitoring/src/wlan_monitor.py
+++ b/cob_monitoring/src/wlan_monitor.py
@@ -107,7 +107,7 @@ class IwConfigSSH(IwConfigParser):
                 key_filename=ssh_key_file,
             ) # no passwd needed
         else:
-            self.ssh.connect(
+            self.ssh.connect(  # pylint: disable=unexpected-keyword-arg
                 str(hostname),
                 username=user,
                 key_filename=ssh_key_file,

--- a/cob_monitoring/src/wlan_monitor.py
+++ b/cob_monitoring/src/wlan_monitor.py
@@ -14,13 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import getpass
 import re
 import os
-import sys
+import getpass
 import traceback
-from subprocess import Popen, PIPE
 import paramiko
+from subprocess import Popen, PIPE
+from packaging import version
 
 import rospy
 from diagnostic_msgs.msg import DiagnosticArray, DiagnosticStatus, KeyValue
@@ -100,12 +100,19 @@ class IwConfigSSH(IwConfigParser):
         self.ssh.load_system_host_keys()
         ssh_key_file   = os.getenv("HOME")+'/.ssh/id_rsa.pub'
         self.ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())# no known_hosts error
-        self.ssh.connect(
-            str(hostname),
-            username=user,
-            key_filename=ssh_key_file,
-            disabled_algorithms={"pubkeys": ["rsa-sha2-256", "rsa-sha2-512"]}
-        ) # no passwd needed
+        if version.parse(paramiko.__version__) < version.parse("2.11.0"):
+            self.ssh.connect(
+                str(hostname),
+                username=user,
+                key_filename=ssh_key_file,
+            ) # no passwd needed
+        else:
+            self.ssh.connect(
+                str(hostname),
+                username=user,
+                key_filename=ssh_key_file,
+                disabled_algorithms={"pubkeys": ["rsa-sha2-256", "rsa-sha2-512"]}
+            ) # no passwd needed
         #self.ssh.connect(str(hostname), username=user, password=password)
 
         self.interfaces = []


### PR DESCRIPTION
ref https://github.com/4am-robotics/orga/issues/3210
This PR fixes the login of the `wlan_monitor.py`. This was related to a paramiko version upgrade to `2.11`
