### PR TITLE
[kevin] throttle identical loginfo stream

### DIFF
--- a/cob_helper_tools/src/cob_auto_tools/auto_recover.py
+++ b/cob_helper_tools/src/cob_auto_tools/auto_recover.py
@@ -61,7 +61,7 @@ class AutoRecover():
               rospy.loginfo("auto_recover from diagnostic failure")
               self.recover([component])
     else:
-      rospy.loginfo_once("auto_recover from diagnostic failure is disabled")
+      rospy.loginfo_once("auto_recover from diagnostic failure is disabled")  # pylint: disable=no-member
 
   # callback for enable service
   def enable_cb(self, req):

--- a/cob_helper_tools/src/cob_auto_tools/auto_recover.py
+++ b/cob_helper_tools/src/cob_auto_tools/auto_recover.py
@@ -58,9 +58,9 @@ class AutoRecover():
       for component in list(self.components.keys()):
         if status.name.lower().startswith(self.components[component].lower()) and status.level > DiagnosticStatus.OK and self.em_state == EmergencyStopState.EMFREE and (rospy.Time.now() - self.components_recover_time[component] > rospy.Duration(10)):
           if not self.recover_diagnostics:
-            rospy.loginfo("auto_recover from diagnostic failure is disabled")
+            rospy.loginfo_throttle_identical(10, "auto_recover from diagnostic failure is disabled")
           else:
-            rospy.loginfo("auto_recover from diagnostic failure")
+            rospy.loginfo_throttle_identical(10, "auto_recover from diagnostic failure")
             self.recover([component])
 
   # callback for enable service

--- a/cob_helper_tools/src/cob_auto_tools/auto_recover.py
+++ b/cob_helper_tools/src/cob_auto_tools/auto_recover.py
@@ -54,14 +54,14 @@ class AutoRecover():
 
   # auto recover based on diagnostics
   def diagnostics_cb(self, msg):
-    for status in msg.status:
-      for component in list(self.components.keys()):
-        if status.name.lower().startswith(self.components[component].lower()) and status.level > DiagnosticStatus.OK and self.em_state == EmergencyStopState.EMFREE and (rospy.Time.now() - self.components_recover_time[component] > rospy.Duration(10)):
-          if not self.recover_diagnostics:
-            rospy.loginfo_throttle_identical(10, "auto_recover from diagnostic failure is disabled")
-          else:
-            rospy.loginfo_throttle_identical(10, "auto_recover from diagnostic failure")
-            self.recover([component])
+    if self.recover_diagnostics:
+      for status in msg.status:
+        for component in list(self.components.keys()):
+          if status.name.lower().startswith(self.components[component].lower()) and status.level > DiagnosticStatus.OK and self.em_state == EmergencyStopState.EMFREE and (rospy.Time.now() - self.components_recover_time[component] > rospy.Duration(10)):
+              rospy.loginfo("auto_recover from diagnostic failure")
+              self.recover([component])
+    else:
+      rospy.loginfo_once("auto_recover from diagnostic failure is disabled")
 
   # callback for enable service
   def enable_cb(self, req):


### PR DESCRIPTION
ref https://github.com/4am-robotics/orga/issues/3210
includes https://github.com/ipa320/cob_command_tools/pull/323
If the `auto_recover` on diagnostics is disabled, the node is spamming the loginfo stream for each component. This PR reduces the output.
