### PR TITLE
Fix NTP monitor

### DIFF
--- a/cob_monitoring/src/ntp_monitor.py
+++ b/cob_monitoring/src/ntp_monitor.py
@@ -62,6 +62,7 @@ class NtpMonitor():
                 stdout, stderr = p.communicate()
                 try:
                     stdout = stdout.decode()  #python3
+                    stderr = stderr.decode()  #python3
                 except (UnicodeDecodeError, AttributeError):
                     pass
 


### PR DESCRIPTION
Fixes crashing of NTP monitor on stderr output of `ntpdate`.

Based on https://github.com/ipa320/cob_command_tools/pull/324

