### PR TITLE
Collect only error and stale messages as errors

### DIFF
--- a/cob_monitoring/src/emergency_stop_monitor.py
+++ b/cob_monitoring/src/emergency_stop_monitor.py
@@ -109,7 +109,7 @@ class emergency_stop_monitor():
 		#all diagnostics that have warning/error/stale
 		for status in msg.status:
 			if "Safety" in status.name:
-				if status.level > DiagnosticStatus.OK:
+				if status.level > DiagnosticStatus.WARN:
 					diagnostics_errors.append(status)
 
 		#reduce list to most detailed description only


### PR DESCRIPTION
The diagnostic level was increased that warnings doesn't count as errors. This fixes that the topics like `/brake_release` get notified even if there are warnings in diagnostics.