### PR TITLE
Reconnect if SSH session is inactive

### DIFF
--- a/cob_monitoring/src/wlan_monitor.py
+++ b/cob_monitoring/src/wlan_monitor.py
@@ -147,14 +147,12 @@ class IwConfigSSH(IwConfigParser):
             try:
                 self.connect()
             except Exception as e:
-                message = "IwConfigSSH update exception: %s" % e
+                message = "IwConfigSSH connect exception: %s" % e
                 self.stat.level = DiagnosticStatus.ERROR
                 self.stat.message = message
-                self.stat.values = [ KeyValue(key="ssh_connection_active", value="False"), KeyValue(key = 'Exception', value = str(e)), KeyValue(key = 'Traceback', value = str(traceback.format_exc())) ]
+                self.stat.values = [ KeyValue(key = 'Exception', value = str(e)), KeyValue(key = 'Traceback', value = str(traceback.format_exc())) ]
                 rospy.logerr(message)
                 return
-
-        self.stat.values.append(KeyValue(key="ssh_connection_active", value="True"))
 
         for interface in self.interfaces:
             self.stat.values.append(KeyValue(key = str(interface), value = "======================="))


### PR DESCRIPTION
The `wlan_monitor` node doesn't reconnect if the SSH connection was closed on either side which requires a restart of the node to get diagnostics `OK` again. With the change, the node tries a reconnect.