### PR TITLE
extend battery_monitor with additional rosparams

### DIFF
--- a/cob_monitoring/src/battery_monitor.py
+++ b/cob_monitoring/src/battery_monitor.py
@@ -75,8 +75,8 @@ class battery_monitor():
         self.color_critical = ColorRGBA(*color_critical_param)
 
         self.interval_duration_warning = rospy.get_param("~interval_duration_warning", 30.0)
-        self.interval_duration_error = rospy.get_param("~interval_duration_error", 30.0)
-        self.interval_duration_critical = rospy.get_param("~interval_duration_critical", 30.0)
+        self.interval_duration_error = rospy.get_param("~interval_duration_error", 15.0)
+        self.interval_duration_critical = rospy.get_param("~interval_duration_critical", 5.0)
 
         self.track_id_light = {}
         if self.enable_light:


### PR DESCRIPTION
Added rosparams for:
- color_charging
- color_warning
- color_error
- color_critical
- interval_duration_warning
- interval_duration_error
- interval_duration_critical

The default values for the rosparams are the same as before. So if the new parameters are not on the parameter server loaded the behavior of this node should be the same as before.