### PR TITLE
fixed em topic based emergency_stop_monitor

### DIFF
--- a/cob_monitoring/src/emergency_stop_monitor.py
+++ b/cob_monitoring/src/emergency_stop_monitor.py
@@ -264,7 +264,7 @@ class emergency_stop_monitor():
 				self.set_light(self.color_warn, True)
 
 	## Topic Monitoring
-	def emergency_stop_callback(self, msg: EmergencyStopState):
+	def emergency_stop_callback(self, msg):
 		if msg.emergency_state == EmergencyStopState.EMSTOP:
 			if not self.last_em_topic_state == msg.emergency_state:
 				if msg.emergency_button_stop:


### PR DESCRIPTION
fixes https://github.com/4am-robotics/orga/issues/4657

- send a light command only if the state changes
- use the state field to decide if an em is active. => em could be active without button or laser being true.